### PR TITLE
LSBization

### DIFF
--- a/templates/fakesqs.init.sh.j2
+++ b/templates/fakesqs.init.sh.j2
@@ -4,6 +4,15 @@
 #
 # chkconfig: 3 50 50
 # description: Fake SQS init.d
+### BEGIN INIT INFO
+# Provides:          fakesqs
+# Required-Start:    $remote_fs $syslog
+# Required-Stop:     $remote_fs $syslog
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: FakeSQS daemon
+### END INIT INFO
+
 source /etc/profile.d/rvm.sh
 prog=fake_sqs
 pidfile=/var/run/fake_sqs.pid

--- a/tests/main.yml
+++ b/tests/main.yml
@@ -1,0 +1,9 @@
+---
+# The name of your test
+name: "Installation"
+playbook:
+- hosts: all
+  sudo: yes
+  roles:
+  - role: "@ROLE_NAME@"
+


### PR DESCRIPTION
Add proper LSB metadata to init script (required on some distros).
[LSBInitScripts](https://wiki.debian.org/LSBInitScripts)

Prevents the following error:

```
failed: [ubuntu15] => {"failed": true}
msg: update-rc.d: error: fakesqs Default-Start contains no runlevels, aborting.
```
